### PR TITLE
Add category translation handling

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -3,63 +3,48 @@
 namespace App\Http\Controllers;
 
 use App\Models\Category;
-use Illuminate\Http\Request;
+use App\Facades\ApiResponse;
+use App\Services\CategoryService;
+use App\Http\Resources\CategoryResource;
+use App\Http\Requests\Dashboard\Categories\CategoryStoreRequest;
+use App\Http\Requests\Dashboard\Categories\CategoryUpdateRequest;
 
 class CategoryController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
-        //
+        $categories = Category::all();
+        return ApiResponse::success(CategoryResource::collection($categories));
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
+    public function store(CategoryStoreRequest $request, CategoryService $service)
     {
-        //
+        try {
+            $category = $service->create($request->validated());
+            return ApiResponse::created(new CategoryResource($category));
+        } catch (\Exception $e) {
+            return ApiResponse::serverError('An error occurred while processing, please try again.');
+        }
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
     public function show(Category $category)
     {
-        //
+        return ApiResponse::success(new CategoryResource($category));
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Category $category)
+    public function update(CategoryUpdateRequest $request, Category $category, CategoryService $service)
     {
-        //
+        try {
+            $category = $service->update($category, $request->validated());
+            return ApiResponse::updated(new CategoryResource($category));
+        } catch (\Exception $e) {
+            return ApiResponse::serverError('An error occurred while processing, please try again.');
+        }
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Category $category)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(Category $category)
     {
-        //
+        $category->delete();
+        return ApiResponse::deleted();
     }
 }

--- a/app/Http/Requests/Dashboard/Categories/CategoryStoreRequest.php
+++ b/app/Http/Requests/Dashboard/Categories/CategoryStoreRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Dashboard\Categories;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CategoryStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'is_active' => 'sometimes|boolean',
+            'name' => 'required|array',
+            'name.en' => 'required|string|max:255',
+            'name.ar' => 'required|string|max:255',
+            'description' => 'nullable|array',
+            'description.*' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/Dashboard/Categories/CategoryUpdateRequest.php
+++ b/app/Http/Requests/Dashboard/Categories/CategoryUpdateRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Dashboard\Categories;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CategoryUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'is_active' => 'sometimes|boolean',
+            'name' => 'required|array',
+            'name.en' => 'required|string|max:255',
+            'name.ar' => 'required|string|max:255',
+            'description' => 'nullable|array',
+            'description.*' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CategoryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->translate(app()->getLocale())->name,
+            'description' => $this->translate(app()->getLocale())->description,
+            'is_active' => $this->is_active,
+            'translations' => $this->translations,
+        ];
+    }
+}

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Category;
+
+class CategoryService
+{
+    public function create(array $data): Category
+    {
+        $translations = [
+            'en' => [
+                'name' => $data['name']['en'],
+                'description' => $data['description']['en'] ?? null,
+            ],
+            'ar' => [
+                'name' => $data['name']['ar'],
+                'description' => $data['description']['ar'] ?? null,
+            ],
+        ];
+
+        return Category::create(array_merge($data, $translations));
+    }
+
+    public function update(Category $category, array $data): Category
+    {
+        $translations = [
+            'en' => [
+                'name' => $data['name']['en'],
+                'description' => $data['description']['en'] ?? null,
+            ],
+            'ar' => [
+                'name' => $data['name']['ar'],
+                'description' => $data['description']['ar'] ?? null,
+            ],
+        ];
+
+        $category->update(array_merge($data, $translations));
+
+        return $category;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Application\Auth\AuthController;
 use App\Http\Controllers\Application\Auth\ResetPasswordController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\CategoryController;
 
 Route::post('login', [AuthController::class, 'login']);
 Route::post('signup', [AuthController::class, 'signUp']);
@@ -32,3 +33,4 @@ Route::group(['middleware' => ['auth:sanctum', 'abilities:verified']], function 
 
 
 
+Route::apiResource('categories', CategoryController::class);

--- a/tests/Feature/CategoryTest.php
+++ b/tests/Feature/CategoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CategoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_category_with_translations()
+    {
+        $payload = [
+            'name' => ['en' => 'Yoga', 'ar' => 'يوغا'],
+            'description' => ['en' => 'Yoga desc', 'ar' => 'وصف يوغا'],
+        ];
+
+        $response = $this->postJson('/api/categories', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Yoga')
+            ->assertJsonPath('data.description', 'Yoga desc')
+            ->assertJsonPath('data.translations.en.name', 'Yoga')
+            ->assertJsonPath('data.translations.ar.name', 'يوغا');
+
+        $this->assertDatabaseHas('category_translations', [
+            'name' => 'Yoga',
+            'locale' => 'en',
+        ]);
+        $this->assertDatabaseHas('category_translations', [
+            'name' => 'يوغا',
+            'locale' => 'ar',
+        ]);
+    }
+
+    public function test_show_category_returns_translation_based_on_locale()
+    {
+        $category = Category::create([
+            'en' => ['name' => 'Gym', 'description' => 'English Desc'],
+            'ar' => ['name' => 'نادي', 'description' => 'وصف بالعربية'],
+        ]);
+
+        $this->getJson('/api/categories/'.$category->id)
+            ->assertJsonPath('data.name', 'Gym');
+
+        app()->setLocale('ar');
+
+        $this->getJson('/api/categories/'.$category->id)
+            ->assertJsonPath('data.name', 'نادي');
+    }
+}


### PR DESCRIPTION
## Summary
- validate translation arrays on store and update
- implement service methods for creating and updating category translations
- add category API resource using locale
- expose category endpoints
- test multilingual category storage and retrieval

## Testing
- `phpunit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688bf64ea8508326b3e0d839063f8e43