### PR TITLE
Implement category endpoints

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -3,63 +3,58 @@
 namespace App\Http\Controllers;
 
 use App\Models\Category;
-use Illuminate\Http\Request;
+use App\Facades\ApiResponse;
+use App\Services\CategoryService;
+use App\Http\Resources\CategoryResource;
+use App\Http\Requests\StoreCategoryRequest;
+use App\Http\Requests\UpdateCategoryRequest;
 
 class CategoryController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
+    public function __construct(protected CategoryService $service)
+    {
+    }
+
     public function index()
     {
-        //
+        $categories = $this->service->list(request()->all());
+        return ApiResponse::success(CategoryResource::collection($categories));
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
+    public function store(StoreCategoryRequest $request)
     {
-        //
+        try {
+            $category = $this->service->create($request->validated());
+            return ApiResponse::created(new CategoryResource($category));
+        } catch (\Exception $e) {
+            return ApiResponse::serverError($e->getMessage());
+        }
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
     public function show(Category $category)
     {
-        //
+        $category->loadCount('products');
+        $category->load('translations');
+        return ApiResponse::success(new CategoryResource($category));
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Category $category)
+    public function update(UpdateCategoryRequest $request, Category $category)
     {
-        //
+        try {
+            $category = $this->service->update($category, $request->validated());
+            return ApiResponse::updated(new CategoryResource($category));
+        } catch (\Exception $e) {
+            return ApiResponse::serverError($e->getMessage());
+        }
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Category $category)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(Category $category)
     {
-        //
+        try {
+            $this->service->delete($category);
+            return ApiResponse::deleted();
+        } catch (\Exception $e) {
+            return ApiResponse::serverError($e->getMessage());
+        }
     }
 }

--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\AbstractApiRequest;
+
+class StoreCategoryRequest extends AbstractApiRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'is_active' => 'sometimes|boolean',
+            'translations.en.name' => 'required|string|max:255',
+            'translations.en.description' => 'nullable|string',
+            'translations.ar.name' => 'required|string|max:255',
+            'translations.ar.description' => 'nullable|string',
+            'cover' => 'nullable|image',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\AbstractApiRequest;
+
+class UpdateCategoryRequest extends AbstractApiRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'is_active' => 'sometimes|boolean',
+            'translations.en.name' => 'sometimes|required|string|max:255',
+            'translations.en.description' => 'nullable|string',
+            'translations.ar.name' => 'sometimes|required|string|max:255',
+            'translations.ar.description' => 'nullable|string',
+            'cover' => 'nullable|image',
+        ];
+    }
+}

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'is_active' => (bool) $this->is_active,
+            'cover_url' => $this->getFirstMediaUrl('cover'),
+            'products_count' => $this->products_count ?? $this->products()->count(),
+            'translations' => $this->translations->mapWithKeys(fn($t) => [
+                $t->locale => [
+                    'name' => $t->name,
+                    'description' => $t->description,
+                ],
+            ]),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Category;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+
+class CategoryService
+{
+    public function list(array $filters = [])
+    {
+        $query = Category::query();
+
+        if (!empty($filters['active'])) {
+            $query->where('is_active', (bool) $filters['active']);
+        }
+
+        if (isset($filters['with'])) {
+            $with = array_map('trim', explode(',', $filters['with']));
+            $query->with($with);
+        }
+
+        $query->withCount('products');
+
+        return $query->paginate(Arr::get($filters, 'limit', 10));
+    }
+
+    public function create(array $data): Category
+    {
+        return DB::transaction(function () use ($data) {
+            $translations = Arr::pull($data, 'translations', []);
+            $category = Category::create($data);
+            foreach ($translations as $locale => $fields) {
+                $category->translateOrNew($locale)->fill($fields);
+            }
+            $category->save();
+
+            if (isset($data['cover'])) {
+                $category->addMedia($data['cover'])->toMediaCollection('cover');
+            }
+            return $category;
+        });
+    }
+
+    public function update(Category $category, array $data): Category
+    {
+        return DB::transaction(function () use ($category, $data) {
+            $translations = Arr::pull($data, 'translations', []);
+            $category->update($data);
+            foreach ($translations as $locale => $fields) {
+                $category->translateOrNew($locale)->fill($fields);
+            }
+            $category->save();
+
+            if (isset($data['cover'])) {
+                $category->clearMediaCollection('cover');
+                $category->addMedia($data['cover'])->toMediaCollection('cover');
+            }
+
+            return $category;
+        });
+    }
+
+    public function delete(Category $category): void
+    {
+        $category->delete();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Application\Auth\AuthController;
 use App\Http\Controllers\Application\Auth\ResetPasswordController;
+use App\Http\Controllers\CategoryController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('login', [AuthController::class, 'login']);
@@ -23,6 +24,8 @@ Route::prefix('password')->group(function (){
 Route::group(['middleware' => ['auth:sanctum', 'abilities:verified']], function () {
     Route::post('logout', [AuthController::class, 'logout']);
 });
+
+Route::apiResource('categories', CategoryController::class);
 
 
 


### PR DESCRIPTION
## Summary
- add CategoryService to handle business logic
- add CategoryResource for structured JSON
- add StoreCategoryRequest and UpdateCategoryRequest
- implement CategoryController using service and resource
- register category routes

## Testing
- `composer dump-autoload --no-scripts`
- `php vendor/bin/phpunit` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_b_688bfb012e8c8326b4131440d1082996