### PR TITLE
Load translations conditionally

### DIFF
--- a/app/Http/Controllers/Application/CategoryController.php
+++ b/app/Http/Controllers/Application/CategoryController.php
@@ -29,10 +29,8 @@ class CategoryController extends Controller
     public function show(string $id)
     {
         try {
-            $category = $this->service->find($id, true);
+            $category = $this->service->find($id, true, ['translations', 'products']);
             $category->loadCount('products');
-            $category->load('products');
-            $category->load('translations');
             return ApiResponse::success(new CategoryResource($category));
         }catch (ModelNotFoundException $e) {
             return ApiResponse::notFound('Category not found.');

--- a/app/Http/Controllers/Application/ProductController.php
+++ b/app/Http/Controllers/Application/ProductController.php
@@ -29,8 +29,7 @@ class ProductController extends Controller
     public function show(string $id)
     {
         try {
-            $product = $this->service->find($id, true);
-            $product->load(['translations', 'category', 'brand']);
+            $product = $this->service->find($id, true, ['translations', 'category', 'brand']);
             return ApiResponse::success(new ProductResource($product));
         } catch (ModelNotFoundException $e) {
             return ApiResponse::notFound('Product not found.');

--- a/app/Http/Controllers/Dashboard/CategoryController.php
+++ b/app/Http/Controllers/Dashboard/CategoryController.php
@@ -38,10 +38,8 @@ class CategoryController extends Controller
     public function show(string $id)
     {
         try {
-            $category = $this->service->find($id);
+            $category = $this->service->find($id, with: ['translations', 'products']);
             $category->loadCount('products');
-            $category->load('products');
-            $category->load('translations');
             return ApiResponse::success(new CategoryResource($category));
         }catch (ModelNotFoundException $e) {
             return ApiResponse::notFound('Category not found.');

--- a/app/Http/Controllers/Dashboard/ProductController.php
+++ b/app/Http/Controllers/Dashboard/ProductController.php
@@ -39,8 +39,7 @@ class ProductController extends Controller
     public function show(string $id)
     {
         try {
-            $product = $this->service->find($id);
-            $product->load(['translations', 'category', 'brand']);
+            $product = $this->service->find($id, with: ['translations', 'category', 'brand']);
             return ApiResponse::success(new ProductResource($product));
         } catch (ModelNotFoundException $e) {
             return ApiResponse::notFound('Product not found.');

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -21,12 +21,14 @@ class CategoryResource extends JsonResource
             'is_active' => (bool) $this->is_active,
             'cover_url' => $this->getFirstMediaUrl('cover'),
             'products_count' => $this->products_count ?? $this->products()->count(),
-            'translations' => $this->translations->mapWithKeys(fn($t) => [
-                $t->locale => [
-                    'name' => $t->name,
-                    'description' => $t->description,
-                ],
-            ]),
+            'translations' => $this->whenLoaded('translations', fn () =>
+                $this->translations->mapWithKeys(fn($t) => [
+                    $t->locale => [
+                        'name' => $t->name,
+                        'description' => $t->description,
+                    ],
+                ])
+            ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'products' => $this->whenLoaded('products', function () {

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -24,12 +24,14 @@ class ProductResource extends JsonResource
             'brand' => $this->whenLoaded('brand',function () {
                return new BrandResource($this->brand);
             }),
-            'translations' => $this->translations->mapWithKeys(fn($t) => [
-                $t->locale => [
-                    'name' => $t->name,
-                    'description' => $t->description,
-                ],
-            ]),
+            'translations' => $this->whenLoaded('translations', fn () =>
+                $this->translations->mapWithKeys(fn($t) => [
+                    $t->locale => [
+                        'name' => $t->name,
+                        'description' => $t->description,
+                    ],
+                ])
+            ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -71,12 +71,13 @@ class CategoryService
     }
 
 
-    public function find(string $id, $isActive = false): Category
+    public function find(string $id, $isActive = false, array $with = []): Category
     {
         try {
             return Category::when($isActive, function($q){
                 return $q->where('is_active', true);
             })
+            ->with($with)
             ->where('id', $id)
             ->firstOrFail();
         } catch (ModelNotFoundException $e) {

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -70,12 +70,13 @@ class ProductService
         $product->delete();
     }
 
-    public static function find(string $id, $isActive = false): Product
+    public static function find(string $id, $isActive = false, array $with = []): Product
     {
         try {
             return Product::when($isActive, function($q){
                 return $q->where('is_active', true);
             })
+            ->with($with)
             ->where('id', $id)
             ->firstOrFail();
         } catch (ModelNotFoundException $e) {


### PR DESCRIPTION
## Summary
- Only serialize product and category translations when the relation is preloaded
- Allow services to eager-load relations via new `$with` argument and update controllers

## Testing
- `composer install` *(fails: curl error 56, CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6891aa769f1c83269ac93debf18a7807